### PR TITLE
ESVC-127 Move WOT to its own grouping in docs

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -713,6 +713,8 @@ IN PROGRESS
 + Response 200 (application/json)
     + Attributes (Work Order Task)
 
+# Group Work Order Templates
+
 ## Work Order Template Collection [/accounts/{accountId}/workordertemplates{?page,pagesize,orderby,purpose}]
 
 + Parameters


### PR DESCRIPTION
WOT is currently listed under WorkOrders. Moves it to its own grouping for SDK calls in event worker.
